### PR TITLE
docs: add Deploy on Hostinger button

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,7 @@ new people that already use Horizon UI!
 ⭐️ [Copyright 2022 Simmmple ](https://www.simmmple.com/?ref=readme-horizon-ts)
 
 📄 [Horizon UI License](https://www.simmmple.com/licenses?ref=readme-horizon-ts)
+
+## Deployment
+
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/web-apps-hosting)


### PR DESCRIPTION
This PR adds an optional **Deploy on Hostinger** badge to the README (docs-only change).

- Only README is changed
- No code, runtime, or build behavior changes
- The destination URL can be maintainer-controlled (standard Hostinger page or your own partner/affiliate link)

If this is not aligned with project policy, I can close the PR.